### PR TITLE
Add CORS test for API Gateway

### DIFF
--- a/aws/api-gateway/cors-setup/test-service/handler.js
+++ b/aws/api-gateway/cors-setup/test-service/handler.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// Your first function handler
+module.exports.hello = (event, context, cb) => cb(null,
+  { message: 'Hello from API Gateway!', event }
+);

--- a/aws/api-gateway/cors-setup/test-service/serverless.yml
+++ b/aws/api-gateway/cors-setup/test-service/serverless.yml
@@ -1,0 +1,26 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          method: GET
+          path: simple-cors
+          cors: true
+      - http:
+          method: GET
+          path: complex-cors
+          cors:
+            origins:
+              - '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token

--- a/aws/api-gateway/cors-setup/tests.js
+++ b/aws/api-gateway/cors-setup/tests.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const BbPromise = require('bluebird');
+const AWS = require('aws-sdk');
+const _ = require('lodash');
+const fetch = require('node-fetch');
+
+const Utils = require('../../../utils/index');
+
+const CF = new AWS.CloudFormation({ region: 'us-east-1' });
+BbPromise.promisifyAll(CF, { suffix: 'Promised' });
+
+describe('AWS - API Gateway: CORS setup test', () => {
+  let stackName;
+  let endpointBase;
+
+  before(function () {
+    this.timeout(0);
+
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'test-service'));
+    Utils.deployService();
+  });
+
+  it('should expose the endpoint(s) in the CloudFormation Outputs', function () {
+    this.timeout(0);
+
+    return CF.describeStacksPromised({ StackName: stackName })
+      .then((result) => _.find(result.Stacks[0].Outputs,
+        { OutputKey: 'ServiceEndpoint' }).OutputValue)
+      .then((endpointOutput) => {
+        endpointBase = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+      });
+  });
+
+  it('should setup CORS support with simple string config', function () {
+    this.timeout(0);
+
+    return fetch(`${endpointBase}/simple-cors`, { method: 'OPTIONS' })
+      .then((response) => {
+        const headers = response.headers;
+
+        expect(headers.get('access-control-allow-headers'))
+          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+        expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
+        expect(headers.get('access-control-allow-origin')).to.equal('*');
+      });
+  });
+
+  it('should setup CORS support with complex object config', function () {
+    this.timeout(0);
+
+    return fetch(`${endpointBase}/complex-cors`, { method: 'OPTIONS' })
+      .then((response) => {
+        const headers = response.headers;
+
+        expect(headers.get('access-control-allow-headers'))
+          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+        expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
+        expect(headers.get('access-control-allow-origin')).to.equal('*');
+      });
+  });
+
+  after(function () {
+    this.timeout(0);
+
+    Utils.removeService();
+  });
+});

--- a/tests.js
+++ b/tests.js
@@ -7,6 +7,7 @@ require('./aws/general/deploy-invoke-remove-lifecycle/tests');
 // API Gateway
 require('./aws/api-gateway/simple-api-setup/tests');
 require('./aws/api-gateway/custom-authorizers-setup/tests');
+require('./aws/api-gateway/cors-setup/tests');
 
 // Custom resources
 require('./aws/general/custom-resources/tests');


### PR DESCRIPTION
Adds simple and complex cors configuration by inspecting the headers of the `OPTIONS` preflight request.

/cc @eahefnawy @flomotlik 