### PR TITLE
Add subdirectory for tmpDirs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+tmpdirs-serverless

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ admin.env
 .env
 tmp
 .coveralls.yml
+tmpdirs-serverless-integration-test-suite

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ admin.env
 .env
 tmp
 .coveralls.yml
-tmpdirs-serverless-integration-test-suite
+tmpdirs-serverless

--- a/utils/index.js
+++ b/utils/index.js
@@ -15,7 +15,9 @@ module.exports = {
 
   createTestService: (templateName, testServiceDir) => {
     const serviceName = `service-${(new Date()).getTime().toString()}`;
-    const tmpDir = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+    const tmpDir = path.join(os.tmpdir(),
+      'tmpdirs-serverless-integration-test-suite',
+      crypto.randomBytes(8).toString('hex'));
 
     fse.mkdirsSync(tmpDir);
     process.chdir(tmpDir);

--- a/utils/index.js
+++ b/utils/index.js
@@ -16,7 +16,8 @@ module.exports = {
   createTestService: (templateName, testServiceDir) => {
     const serviceName = `service-${(new Date()).getTime().toString()}`;
     const tmpDir = path.join(os.tmpdir(),
-      'tmpdirs-serverless-integration-test-suite',
+      'tmpdirs-serverless',
+      'integration-test-suite',
       crypto.randomBytes(8).toString('hex'));
 
     fse.mkdirsSync(tmpDir);


### PR DESCRIPTION
This makes working with Docker way easier as one has no need to remove the individual tmpDirs but just the directory they are now created in (Running the tests in Docker causes to create the tmpDirs in the root directory).